### PR TITLE
fix forvo - handle case when the word is capitalized on the website

### DIFF
--- a/audiofiles/src/main/python/forvo.py
+++ b/audiofiles/src/main/python/forvo.py
@@ -12,7 +12,9 @@ class ForvoParser:
         doc = BeautifulSoup(data, 'html.parser')
         self._get_javascript_values(doc)
         div = doc.find('div', id='language-container-{0}'.format(language))
-        span = div.find('span', class_='play', title='Listen {0} pronunciation'.format(word)) if div else None
+        span = div.find('span', class_='play', title='Listen {0} pronunciation'.format(word))
+        if not span:
+            span = div.find('span', class_='play', title='Listen {0} pronunciation'.format(word.capitalize()))
         return self._parse_tag(span) if span else None
 
     def _get_javascript_values(self, doc):


### PR DESCRIPTION
Hello,

For example, when I searched for bromide or snick on Anki, the add-on didn't return anything because on the Forvo website, the words are capitalized. So I added another div.find, this time with the word capitalized and it works, at least on my end.