### PR TITLE
fix previous commit when div is None

### DIFF
--- a/audiofiles/src/main/python/forvo.py
+++ b/audiofiles/src/main/python/forvo.py
@@ -12,10 +12,15 @@ class ForvoParser:
         doc = BeautifulSoup(data, 'html.parser')
         self._get_javascript_values(doc)
         div = doc.find('div', id='language-container-{0}'.format(language))
-        span = div.find('span', class_='play', title='Listen {0} pronunciation'.format(word))
-        if not span:
-            span = div.find('span', class_='play', title='Listen {0} pronunciation'.format(word.capitalize()))
-        return self._parse_tag(span) if span else None
+        if div:
+            span = div.find('span', class_='play', title='Listen {0} pronunciation'.format(
+                word))
+            if not span:
+                span = div.find('span', class_='play', title='Listen {0} pronunciation'.format(
+                    word.capitalize()))
+            return self._parse_tag(span)
+        else:
+            return None
 
     def _get_javascript_values(self, doc):
         self._protocol = None


### PR DESCRIPTION
Sorry, my previous commit breaks the code when doc.find() doesn't return anything. The variable div is None and then you've got "AttributeError: 'NoneType' object has no attribute 'find'" just right after. I fixed it.